### PR TITLE
Specify PyPi dependencies, update url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,10 @@ setup(
                       'python library.',
         author      = 'Martín Ferrari, Alina Quereilhac',
         author_email = 'martin.ferrari@gmail.com, aquereilhac@gmail.com',
-        url         = 'http://code.google.com/p/nemu/',
+        url         = 'https://github.com/TheTincho/nemu',
         license     = 'GPLv2',
         platforms   = 'Linux',
         packages    = ['nemu'],
+        install_requires = ['python-unshare', 'python-passfd'],
         package_dir = {'': 'src'}
         )


### PR DESCRIPTION
Hello,

I installed Nemu with `pip2` and I realized that the package did not specify its PyPi dependencies. Now, when installing Nemu, `python-unshare` and `python-passfd` are automatically installed too.
I also updated the url.

On a side note, could you consider replacing the shebangs `#!/usr/bin/env python` to `#!/usr/bin/env python2`?

Thanks!